### PR TITLE
jinfer: exclude Gemma 4 per-layer embeddings from load-time packing

### DIFF
--- a/jinfer/jinfer-kernels/src/main/java/com/qxotic/jinfer/kernels/JamPack.java
+++ b/jinfer/jinfer-kernels/src/main/java/com/qxotic/jinfer/kernels/JamPack.java
@@ -36,7 +36,7 @@ final class JamPack {
 
     /** Row-read outside matmul (embedding lookup; covers the tied-LM-head case). Never packed. */
     private static boolean rowRead(String name) {
-        return name.equals("token_embd.weight");
+        return name.equals("token_embd.weight") || name.equals("per_layer_token_embd.weight");
     }
 
     private record Job(

--- a/jinfer/jinfer-kernels/src/test/java/com/qxotic/jinfer/kernels/JamPackTest.java
+++ b/jinfer/jinfer-kernels/src/test/java/com/qxotic/jinfer/kernels/JamPackTest.java
@@ -159,11 +159,15 @@ class JamPackTest {
         var odd = Views.wrap(canonical(DataType.Q4_K, 6, 256, 3), DataType.Q4_K, Shape.flat(6, 1));
         var q8 = Views.wrap(Oracles.q8(arena, 8, 256, 4), DataType.Q8_0, Shape.flat(8, 8));
         views.put("token_embd.weight", embd); // row-read (embedding lookup)
+        views.put(
+                "per_layer_token_embd.weight",
+                embd); // row-read (Gemma 4 per-layer embedding lookup)
         views.put("flat", flat); // rank 1
         views.put("odd", odd); // rows % 4 != 0
         views.put("q8", q8); // no packed layout for the dtype
         Map<String, MemoryView<MemorySegment>> out = JamPack.apply(views, arena, SPEC);
         assertSame(embd, out.get("token_embd.weight"));
+        assertSame(embd, out.get("per_layer_token_embd.weight"));
         assertSame(flat, out.get("flat"));
         assertSame(odd, out.get("odd"));
         assertSame(q8, out.get("q8"));


### PR DESCRIPTION
### Summary

Gemma 4 models (e.g. `gemma-4-E2B-it`, `gemma-4-26B-A4B-it`) introduce an auxiliary per-layer embedding table named `per_layer_token_embd.weight`.

Because `JamPack.rowRead` only matched `token_embd.weight`, `per_layer_token_embd.weight` was packed into a 4-row interleaved matrix layout at load time. When the model performed embedding lookup on this tensor via `Convert.copyToF32`, it threw:
```
java.lang.UnsupportedOperationException: scalar decode q5_k+jam
```

### Changes

- Exclude `per_layer_token_embd.weight` from packing in `JamPack.java`.
- Add a test case in `JamPackTest.java` to ensure `per_layer_token_embd.weight` retains its canonical layout.

### Verification

- Ran `mvn -pl jinfer/jinfer-kernels test -Dtest=JamPackTest` across all tiers — all 12 tests pass.
- Formatted via `mvn spotless:check` / `spotless:apply`.
- Verified on Apple Silicon (macOS) with `gemma-4-E2B-it-Q4_K_M.gguf` under GraalVM JDK 25: model loads cleanly and inference completes successfully.